### PR TITLE
issue#18 create action bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 					<div class="col">y: <span id="div_y"></span></div>
 				</div>
 				<input class="form-control form-control-sm" disabled type="text" id="ptnboxlbl" placeholder="Box Label">
-				<input type="button" class="btn btn-outline-danger deleteBtn" value="Delete">
+				
 				<hr>
 			</div>
 			<div id="boxDtl"  class="widget">
@@ -88,8 +88,6 @@
 					<div class="col">w: <span id="div_w"></span></div>
 					<div class="col">h: <span id="div_h"></span></div>
 				</div>
-				<input type="button" class="btn btn-outline-danger btn-sm deleteBtn" value="Delete">
-				<input type="button" class="btn btn-outline-danger btn-sm" id="emptyBox" value="Empty">
 				<hr>
 			</div>
 
@@ -97,6 +95,8 @@
 		</div>
 		<div class="col-sm-8" >
 			<input type="checkbox" name="plotType" id="plotType" checked data-on-text="Box" data-off-text="Points">
+			<input type="button" class="btn btn-outline-danger btn-sm deleteBtn" value="Delete">
+			<input type="button" class="btn btn-outline-danger btn-sm" id="emptyBox" value="Empty">
 			<div style="height: 600px">
 				<div id="img_home">
 					<img id="img"/>

--- a/js/uiaction.js
+++ b/js/uiaction.js
@@ -196,12 +196,14 @@ $("#img_overlay").mousedown(function (ev) {
     
 });
 
-//decide if box or point should be dragged
+//decide if box or point should be dragged and if empty button is visible
 $("#plotType").on("switchChange.bootstrapSwitch",function(ev){
     if(document.getElementById('plotType').checked){
         jsPlumb.setDraggable($(".facebox"),true);
+		$("#emptyBox").slideDown(100);
     }else{
         jsPlumb.setDraggable($(".facebox"),false);
+		$("#emptyBox").slideUp(200);
     }
 });
 
@@ -256,6 +258,7 @@ $(".deleteBtn").click(function(){
     $(".selected").remove();
     hideWidgets();
 });
+
 
 $("#emptyBox").click(function(){
     $(".selected").empty();


### PR DESCRIPTION
Moved the 'delete' and 'empty' buttons out of the widget to above the image.  The 'empty' button hides when "Points" is selected.

# Purpose / Goal
Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. 

Create an action bar between canvas and thumbnail slider with "delete", "empty", "move" buttons. Appropriate options should be visible or enable. Eg when a feature point is selected then "empty" option either should not be visible or disabled.

Please mention the issue number, if exists.

Issue #18 

# Type
Please mention the type of PR


[x ] Bug Fix

[ ] Refactoring / Technology upgrade

[ ] New Feature

[ ] Documentation

[ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
