### PR TITLE
Fix Issue #42: Firefox UI : Bootstrap : Extra space above the row

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -1,6 +1,5 @@
 .dropbtn {
     color: white;
-    padding: 16px;
     font-size: 16px;
     border: none;
 }


### PR DESCRIPTION
Fix padding for button. This padding appear in Firefox. On Chrome this padding visible on hover.

# Purpose / Goal
Fixing issue #42.

# Type
Please mention the type of PR


* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
