### PR TITLE
Fixed Alt-A To Select All Items

### DIFF
--- a/tags/workarea.tag.html
+++ b/tags/workarea.tag.html
@@ -50,9 +50,11 @@
                 selectedElements = [];
                 //delete all the points related to a polygon
                 //show snakebar to inform
-            } else if (e.key == 'a' && e.altKey) {//TODO change this
+            } else if (e.key === 'a' && e.altKey) {//TODO change this
                 //Select all the labels
                 selectAll();
+                e.preventDefault();
+                e.stopPropagation();
             } else if (e.key === 'c' && e.ctrlKey) {
                 /**
                  * Save selected shape and feature point data into copiedElements
@@ -330,13 +332,14 @@
         }
 
         function selectAll() {
-            for (var shapeId in labellingData[imgSelected.name].shapes) {
-                var el = SVG.get(shapeId)
+            labellingData[imgSelected.name].shapes.forEach(shape => {
+                let el = SVG.get(shape.id);
                 el.selectize({
                     rotationPoint: false
                 });
                 selectedElements.push(el);
-            };
+            });
+            console.log('selectedElements', selectedElements);
         }
 
         // When create, move, resize, delete


### PR DESCRIPTION
# Purpose / Goal
Fixed Alt-A to select all items. The reason for the bug was because the index was passed instead of the shape id in selectAll(),

Related to #108  

# Type
Please mention the type of PR
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
