### PR TITLE
Issue #85 - removed svg zoom min ref in index which is no longer used

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,6 @@
 	<script src="js/thirdparty/svg.select.min.js"></script>
 	<script src="js/thirdparty/svg.resize.min.js"></script>
 	<script src="js/thirdparty/svg.draggable.min.js"></script>
-	<script src="js/thirdparty/svg-pan-zoom.min.js"></script>
 
 	<script src="js/storePersistor.js"></script>
 	<script src="js/store.js"></script>


### PR DESCRIPTION
# Purpose / Goal
Found a bug when addressing Issue #85, reference to svg.zoom.min.js which does not exist anymore.

Please mention the issue number, if exists.
#85 

# Type
Please mention the type of PR


* [ x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
