### PR TITLE
Add zoom, zoom in, & zoom out shortcuts

### DIFF
--- a/tags/actions/zoom-action.tag.html
+++ b/tags/actions/zoom-action.tag.html
@@ -70,6 +70,20 @@
     this.on('mount', function () {
       //reset the input box's value according to image scale
       if(imgSelected) $("#zoom-scale").val(Math.round(imgSelected.size.imageScale*100)+'%');
+
+      document.addEventListener('keydown', e=>{
+        if (e.key == '≠') {//Zoom in
+            $("img[data-zoom-type='in']").click();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    
+        if (e.key == '–' && e.altKey) {//Zoom out
+            $("img[data-zoom-type='out']").click();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+      });
     });
 
     function rescaleImage(){

--- a/tags/shortcuts.tag.html
+++ b/tags/shortcuts.tag.html
@@ -32,7 +32,9 @@
                     <tr><td><kbd>Alt</kbd> + <kbd>p</kbd></td><td> Polygon<td></tr>
                     <tr><td><kbd>Alt</kbd> + <kbd>w</kbd></td><td> Magic wand<td></tr>
                     <tr><td><kbd>Alt</kbd> + <kbd>m</kbd></td><td> Move<td></tr>
-                    <tr><td><kbd>Alt</kbd> + <kbd>+</kbd></td><td> Zoom<td></tr>
+                    <tr><td><kbd>Alt</kbd> + <kbd>z</kbd></td><td> Zoom<td></tr>
+                    <tr><td><kbd>Alt</kbd> + <kbd>+</kbd></td><td> Zoom in<td></tr>
+                    <tr><td><kbd>Alt</kbd> + <kbd>-</kbd></td><td> Zoom out<td></tr>
                     <tr><td><kbd>Alt</kbd> + <kbd>l</kbd></td><td> Light<td></tr>
                 </table>
                 `,

--- a/tags/toolbox.tag.html
+++ b/tags/toolbox.tag.html
@@ -66,14 +66,20 @@
                     e.stopPropagation()
                 } */
 
-                if (e.key == 'm'  && e.altKey){//Magic wand
+                if (e.key == 'm'  && e.altKey){//Move
                     $("#tool-move").click();
                     e.preventDefault();
                     e.stopPropagation()
                 }
 
-                if (e.key == 'l'  && e.altKey){//Magic wand
+                if (e.key == 'l'  && e.altKey){//Light
                     $("#tool-light").click();
+                    e.preventDefault();
+                    e.stopPropagation()
+                }
+
+                if (e.key == 'Ω'){//Zoom
+                    $("#tool-zoom").click();
                     e.preventDefault();
                     e.stopPropagation()
                 }


### PR DESCRIPTION
# Purpose / Goal
Added zoom shortcuts specified in [issue #107 ](https://github.com/NaturalIntelligence/imglab/issues/107) 

Hello, 

This is my first real PR - so I hope I'm doing things correctly...

I added a shortcut to 'click' the zoom button. From there the user can then use shortcuts to zoom in or out. I assumed this was the desired effect since the buttons aren't mounted until the zoom button is clicked, correct?

I'm on a mac and was having issues (even with existing shortcuts) with  `e.key == [appropriate key] && e.altKey` working. However when I used the symbol created when pressing both alt and the event key it worked as expected. 

For example `e.key == '=' && e.altKey` didn't work but `e.key == '≠' did` for the alt + '+' shortcut.

If I need to change to the previous formatting of e.key && e.altKey let me know and I can change back. I checked the shortcuts in Chrome, Firefox and Safari.

There were also a couple of quick mis commented items that I fixed. 

# Type
Please mention the type of PR
* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [X] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |