### PR TITLE
Fix toCOCO bbox returning undefined

### DIFF
--- a/dataformaters/coco.js
+++ b/dataformaters/coco.js
@@ -56,7 +56,7 @@ var cocoFormater = {
                     area : area,
                     "iscrowd": 0,
                     "image_id": image_i+1,
-                    "bbox": shape_i.bbox,
+                    "bbox": shape.bbox,
                     "category_id": categories.indexOf(shape.category) + 1,
                     "id": shape_i+1,
                     "ignore": 0


### PR DESCRIPTION
# Purpose / Goal
Fix an error in `toCOCO` in [coco.js](https://github.com/NaturalIntelligence/imglab/blob/master/dataformaters/coco.js) causing the `bbox` property in the resulting COCO formatted data/file to always have a value of `undefined`.

# Cause
`shape_i.bbox` is used to try and get the `bbox` value for the current shape in the for loop. `shape_i` is just the iteration counter though, and has no such property.

# Solution
Change `shape_i` to `shape`, referencing the shape object retrieved at the beginning of the for loop.

# Type
Please mention the type of PR


* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
