### PR TITLE
Fixed: Now restore data prompt doesn't show when localstorage is empty

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class=""
     @click="click">
-    <prompt-restore v-if="showModal" @close="showModal = false"></prompt-restore>
+    <prompt-restore></prompt-restore>
     <div class="container-fluid">
       <div id="menubar" class="row overlay-color align-items-center" style="height: 50px;">
         <div class="col-3 col-sm-2 col-md-1 col-xl-1 no-pl">
@@ -81,8 +81,7 @@ export default {
   data() {
     return {
       LABEL_TAG,
-      CANVAS_TAG,
-      showModal: true
+      CANVAS_TAG
     };
   },
   methods: {

--- a/src/components/prompt-restore-data/restore-data.vue
+++ b/src/components/prompt-restore-data/restore-data.vue
@@ -1,5 +1,8 @@
 <template lang="html">
-  <transition name="modal">
+  <transition
+    name="modal"
+    v-if="show"
+  >
     <div
       class="modal-mask"
     >
@@ -45,6 +48,7 @@ import { mapGetters } from "vuex";
 export default {
   data() {
     return {
+      show: false,
       storeData: null
     };
   },
@@ -62,6 +66,7 @@ export default {
     checkBrowserCache() {
       let cache = this.localStoreData;
       if (!cache) return;
+      this.show = true;
       this.storeData = cache;
     },
 
@@ -69,16 +74,16 @@ export default {
      * Clear local storage and emit close event
      */
     clearCache() {
+      this.show = false;
       localStorage.clear();
-      this.$emit("close");
     },
 
     /**
      * Restores data and emits close event
      */
     restoreData() {
+      this.show = false;
       this.$store.commit("initializeStore", { storeData: this.storeData });
-      this.$emit("close");
     }
   },
   mounted() {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -24,6 +24,7 @@ const mutations = {
 
 const getters = {
   getLocalStoreData: () => {
+    console.log("localStorage", localStorage.getItem("imglab-store"));
     return localStorage.getItem("imglab-store");
   }
 };


### PR DESCRIPTION
# Purpose / Goal
Currently the application doesn't store any data in the localstorage, but the prompt still shows up. Hence added a check to render the prompt during startup.

# Type
Please mention the type of PR
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |
