### PR TITLE
Paste metadata

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -157,10 +157,20 @@ function updateShapeDetailInStore(shapeId, bbox, points){
 /**
  * Adds a shape into labelling data and returns a shape object
  */
-function attachShapeToImg(id, type, bbox, points){
+function attachShapeToImg(id, type, bbox, points, metadata){
     var shape = scaleShape(id, type, bbox, points, 1 / imgSelected.size.imageScale);
+    if (metadata) {
+        shape.label = metadata.label;
+        shape.category = metadata.category;
+    }
     labellingData[ imgSelected.name ].shapes.push(shape);
     return shape;
+}
+
+function getMetadata(shape) {
+    shape = getShape(shape.node.id);
+    return {'label': shape.label,
+            'category': shape.category};
 }
 
 function addImgToStore(imgname, size) {

--- a/js/store.js
+++ b/js/store.js
@@ -30,13 +30,14 @@ function getShape(shapeId){
     return findInArray(labellingData[ imgSelected.name ].shapes, "id", shapeId);
 }
 
-function attachPointToShape(shapeId, pointid, position){
+function attachPointToShape(shapeId, pointid, position, label){
     var shape = getShape(shapeId);
     var scale = 1 / imgSelected.size.imageScale;
+    label = label || shape.featurePoints.length;
     shape.featurePoints.push( {
         "x": position.cx * scale,
         "y": position.cy * scale,
-        "label" : shape.featurePoints.length,
+        "label" : label,
         "id" : pointid
     });
 }
@@ -160,8 +161,11 @@ function updateShapeDetailInStore(shapeId, bbox, points){
 function attachShapeToImg(id, type, bbox, points, metadata){
     var shape = scaleShape(id, type, bbox, points, 1 / imgSelected.size.imageScale);
     if (metadata) {
-        shape.label = metadata.label;
         shape.category = metadata.category;
+        shape.label = metadata.label;
+        shape.attributes = metadata.attributes;
+        shape.tags = metadata.tags;
+        shape.featurePointLabels = metadata.featurePointLabels;
     }
     labellingData[ imgSelected.name ].shapes.push(shape);
     return shape;
@@ -169,8 +173,13 @@ function attachShapeToImg(id, type, bbox, points, metadata){
 
 function getMetadata(shape) {
     shape = getShape(shape.node.id);
-    return {'label': shape.label,
-            'category': shape.category};
+    return {
+            'category': shape.category,
+            'label': shape.label,
+            'attributes': shape.attributes.map(attr => Object.assign({}, attr)),
+            'tags': shape.tags.slice(),
+            'featurePointLabels': shape.featurePoints.map(point => point.label)
+            };
 }
 
 function addImgToStore(imgname, size) {

--- a/tags/workarea.tag.html
+++ b/tags/workarea.tag.html
@@ -71,6 +71,7 @@
                  */
                 copiedElements = [];
                 selectedElements.forEach(shape => {
+                    console.log(getMetadata(shape));
                     if (shape.hasClass('shape')) {
                         var featurePoints = [];
                         shape.siblings()
@@ -86,7 +87,8 @@
                           'type': shape.type,
                           'rbox': shape.rbox(myCanvas),
                           'points': getPoints(shape),
-                          'featurePoints': featurePoints
+                          'featurePoints': featurePoints,
+                          'metadata': getMetadata(shape)
                         });
                     }
                 })
@@ -104,7 +106,7 @@
                     copiedElements.forEach(shape => {
                         // Add shape data and any points into labellingData
                         var shapeId = shape.type + currentImgData.shapeIndex++;
-                        var shapeData = attachShapeToImg(shapeId, shape.type, shape.rbox, shape.points);
+                        var shapeData = attachShapeToImg(shapeId, shape.type, shape.rbox, shape.points, shape.metadata);
                         shape.featurePoints.forEach(point => {
                             var pointId = shapeId + point.type + currentImgData.pointIndex++;
                             attachPointToShape(shapeId, pointId, point.rbox);

--- a/tags/workarea.tag.html
+++ b/tags/workarea.tag.html
@@ -71,7 +71,6 @@
                  */
                 copiedElements = [];
                 selectedElements.forEach(shape => {
-                    console.log(getMetadata(shape));
                     if (shape.hasClass('shape')) {
                         var featurePoints = [];
                         shape.siblings()
@@ -107,10 +106,11 @@
                         // Add shape data and any points into labellingData
                         var shapeId = shape.type + currentImgData.shapeIndex++;
                         var shapeData = attachShapeToImg(shapeId, shape.type, shape.rbox, shape.points, shape.metadata);
-                        shape.featurePoints.forEach(point => {
+                        shape.featurePoints.forEach((point, index) => {
                             var pointId = shapeId + point.type + currentImgData.pointIndex++;
-                            attachPointToShape(shapeId, pointId, point.rbox);
+                            attachPointToShape(shapeId, pointId, point.rbox, shapeData.featurePointLabels[index]);
                         });
+                        delete shape.featurePointLabels;
                     });
                 }
                 // Call update to redraw shapes

--- a/tags/workarea.tag.html
+++ b/tags/workarea.tag.html
@@ -110,6 +110,7 @@
                             var pointId = shapeId + point.type + currentImgData.pointIndex++;
                             attachPointToShape(shapeId, pointId, point.rbox, shapeData.featurePointLabels[index]);
                         });
+                        // feature point labels no longer needed here after attaching feature points
                         delete shape.featurePointLabels;
                     });
                 }


### PR DESCRIPTION
# Purpose / Goal
Implements #115. Copies category, label, feature point labels, clones attribute and tag arrays and then stores them as properties of a metadata object passed into attachShapeToImg. 

This might not be the cleanest implementation. I think it would be better if the shapes in the selectedElements array already had a copy of the metadata, but I wasn't sure how to do that. I am also not completelry sure what the difference between shape and getShape(shape.node.id) is. 

This implementation seems to work though so thought I would make a pull request anyways to see what others think.

# Type
Please mention the type of PR


* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [x] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
