### PR TITLE
add paste images

### DIFF
--- a/tags/images-slider.tag.html
+++ b/tags/images-slider.tag.html
@@ -42,6 +42,7 @@
         var tag = this;
         tag.readImageFiles = readImageFiles;
         tag.readImageFile = readImageFile;
+        tag.pasteImage = pasteImage;
         tag.slideleft = slideleft;
         tag.slideright = slideright;
         tag.deleteThumbnail = deleteThumbnail;
@@ -82,13 +83,23 @@
                     e.stopPropagation();
                 }
             })
+
+            document.addEventListener('paste', e => {
+                
+                clipdata = e.clipboardData || window.clipboardData;
+                    pasteImage(clipdata);
+                    e.preventDefault();
+                    e.stopPropagation();
+            })
+
         });
 
         this.on('updated', () => {
             //$("#thumbnail_0").click(); as this triggers before images are uploaded it cuase issue. Load it with an interval
         })
 
-        function readImageFiles(e) {
+         function readImageFiles(e) {
+            console.log(this);
             var input = e.srcElement || e.target;
             if (input.files && input.files[0]) {
                 for (i = 0; i < input.files.length; i++) {
@@ -105,6 +116,7 @@
             if (f.type.startsWith("image")) {
                 var reader = new FileReader();
                 reader.onload = e => {
+                    console.log(e);
                     var imgData = {
                         name: f.name,
                         src: e.target.result
@@ -134,6 +146,27 @@
                 addImgToStore(imageDataObject.name, imageDataObject.size);
             }
             img.src = imgFileSrc;
+        }
+
+        function pasteImage(clipboardData) {
+            console.log("pasteImage:" + clipboardData);
+            console.log(this);
+            if (!clipboardData.items) {
+                return false;
+            }
+
+            [].forEach.call(clipboardData.items, item => {
+                if (item.type.match(/^image\//)) {
+                    try {
+                        let pastePath  = item.getAsFile();
+                        console.log(pastePath);
+                        tag.readImageFile(pastePath);
+                        } 
+                    catch (error) {
+                       console.log('pasteError', error);
+                    }
+                }
+            });
         }
 
         this.sliding = false;


### PR DESCRIPTION
# Purpose / Goal
Convenience function for my work flow. I have to label medical images on a PACS-Workstation, which does not have a nice and fast image-file export. But copy-and-paste works quite handy and it is easier to save the images from IMGLAB to the target directory. 
Maybe the latter can be improved later.

This is not widely tested and I would have to remove some `console.log()`-stuff before a possible merge.

# Type

* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [x ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


Best regards



