### PR TITLE
fix can't show edit panel after load xml

### DIFF
--- a/js/openfile.js
+++ b/js/openfile.js
@@ -97,7 +97,8 @@ var loadDlibXml = function(data){
                         currentBox.height
                     ],
                     attributes : [],
-                    featurePoints: []
+                    featurePoints: [],
+                    tags: []
                 })
                 if(currentBox.part){
                     if(!Array.isArray(currentBox.part)){


### PR DESCRIPTION
fix can't show edit panel after load dlib xml

# Purpose / Goal
Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. 
fix can't show edit panel after load dlib xml

* mention the issue number, if exists.
* add some video/screenshot highlighting your changes on GUI.
GUI no change.

# Type
Please mention the type of PR

* [*] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [ ] Documentation
* [ ] Other : | Please Specify |


**Note** : Please ensure that you've read contribution [guidelines](CONTRIBUTING.md) before raising this PR.
