### PR TITLE
fix: correct occoured to occurred typo in ZIP error message

### DIFF
--- a/js/savefile.js
+++ b/js/savefile.js
@@ -297,7 +297,7 @@ function yoloDataRendering() {
        analytics_reportExportType("yoloV5PyTorch");
      })
      .catch(function (error) {
-       showSnackBar("Error occoured while creating ZIP file");
+       showSnackBar("Error occurred while creating ZIP file");
        console.error("Error creating ZIP file:", error);
      });
 }


### PR DESCRIPTION
## Summary
Fixes user-facing snackbar error message shown when ZIP file creation fails.

## Change
js/savefile.js line 300: `Error occoured` → `Error occurred`

## Testing
Verified the change is a single surgical fix to the user-facing error string.